### PR TITLE
Add prefix support

### DIFF
--- a/src/cdecl/applies.nim
+++ b/src/cdecl/applies.nim
@@ -1,3 +1,4 @@
+import options
 import macros, typetraits, tables, strformat, strutils, sequtils
 
 macro unpackObjectArgs*(
@@ -166,11 +167,12 @@ proc processLabel(
     varList[fparam.idx] = (fparam.name, lstmt)
 
 type
-  LabelTransformer* = proc (code: (string, NimNode)): (string, NimNode)
+  LabelTransformer* =
+    proc (code: (string, NimNode)): Option[(string, NimNode)]
 
 let noTransforms {.compileTime.} =
-  proc (code: (string, NimNode)): (string, NimNode) = 
-    result = code
+  proc (code: (string, NimNode)): Option[(string, NimNode)] = 
+    result = some(code)
 
 proc unpackLabelsImpl(
     transformer: LabelTransformer,
@@ -191,13 +193,20 @@ proc unpackLabelsImpl(
   for arg in args:
     # echo "LBL_ARGS:ARG: ", arg.treeRepr
     if arg.kind == nnkStmtList:
-      for labelArg in arg:
+      for larg in arg:
+        var labelArg = larg
         # handle `label` args
         idx = -1
         var rcode: (string, NimNode)
 
         case format:
         of LabelFmt, LabelStrictFmt:
+          if labelArg.kind == nnkPrefix:
+            let id = ident(labelArg[0].repr & labelArg[1].repr)
+            copyLineInfo(id, labelArg[0])
+            var larg = nnkCall.newTree(id, labelArg[2])
+            labelArg = larg
+          
           labelArg.expectKind nnkCall
           rcode = (labelArg[0].strVal, labelArg[1])
         of AssignsFmt:
@@ -207,11 +216,13 @@ proc unpackLabelsImpl(
             labelArg.expectKind nnkAsgn
             rcode = (labelArg[0].strVal, labelArg[1])
 
-        let lcode = transformer(rcode)
-        try:
-          varList.processLabel(fnParams, lcode, format)
-        except KeyError:
-          error(fmt"label argument `{lcode[0]}` not found in proc arguments list. Options are: {fnParams.keys().toSeq().repr}", labelArg[0])
+        let tres = transformer(rcode)
+        if tres.isSome():
+          let lcode = tres.get()
+          try:
+            varList.processLabel(fnParams, lcode, format)
+          except KeyError:
+            error(fmt"label argument `{lcode[0]}` not found in proc arguments list. Options are: {fnParams.keys().toSeq().repr}", labelArg[0])
     elif arg.kind in [nnkExprEqExpr, nnkExprColonExpr]:
       # echo "LBL_ARGS:ARG:EXPR: ", arg.treeRepr
       case format:

--- a/src/cdecl/applies.nim
+++ b/src/cdecl/applies.nim
@@ -206,10 +206,13 @@ proc unpackLabelsImpl(
             copyLineInfo(id, labelArg[0])
             var larg = nnkCall.newTree(id, labelArg[2])
             labelArg = larg
-          
           labelArg.expectKind nnkCall
           rcode = (labelArg[0].strVal, labelArg[1])
         of AssignsFmt:
+          if labelArg[0].kind == nnkPrefix:
+            let id = ident(labelArg[0].repr & labelArg[1].repr)
+            copyLineInfo(id, labelArg[0])
+            labelArg[0] = id
           if labelArg.kind == nnkProcDef:
             rcode = (labelArg.name.strVal, labelArg)
           else:

--- a/src/cdecl/applies.nim
+++ b/src/cdecl/applies.nim
@@ -191,7 +191,7 @@ proc unpackLabelsImpl(
   var varList: OrderedTable[int, (string, NimNode)]
   var idx = 0
   for arg in args:
-    # echo "LBL_ARGS:ARG: ", arg.treeRepr
+    # echo "ARG: ", arg.treeRepr
     if arg.kind == nnkStmtList:
       for larg in arg:
         var labelArg = larg
@@ -201,18 +201,24 @@ proc unpackLabelsImpl(
 
         case format:
         of LabelFmt, LabelStrictFmt:
+          ## handle prefixes
           if labelArg.kind == nnkPrefix:
             let id = ident(labelArg[0].repr & labelArg[1].repr)
             copyLineInfo(id, labelArg[0])
             var larg = nnkCall.newTree(id, labelArg[2])
             labelArg = larg
+
+          # handle argument
           labelArg.expectKind nnkCall
           rcode = (labelArg[0].strVal, labelArg[1])
         of AssignsFmt:
+          ## handle prefixes
           if labelArg[0].kind == nnkPrefix:
-            let id = ident(labelArg[0].repr & labelArg[1].repr)
+            let id = ident(labelArg[0][0].strVal & labelArg[0][1].strVal)
             copyLineInfo(id, labelArg[0])
             labelArg[0] = id
+
+          # handle argument
           if labelArg.kind == nnkProcDef:
             rcode = (labelArg.name.strVal, labelArg)
           else:
@@ -226,17 +232,27 @@ proc unpackLabelsImpl(
             varList.processLabel(fnParams, lcode, format)
           except KeyError:
             error(fmt"label argument `{lcode[0]}` not found in proc arguments list. Options are: {fnParams.keys().toSeq().repr}", labelArg[0])
+    
     elif arg.kind in [nnkExprEqExpr, nnkExprColonExpr]:
-      # echo "LBL_ARGS:ARG:EXPR: ", arg.treeRepr
+      var arg = arg
+      ## handle prefixes
+      # echo "LBL: ", arg.treeRepr
+      if arg[0].kind == nnkPrefix:
+        let id = ident(arg[0].repr & arg[1].repr)
+        copyLineInfo(id, arg[0])
+        arg[0] = id
+      
       case format:
       of AssignsFmt: arg.expectKind(nnkExprEqExpr)
       of LabelStrictFmt: arg.expectKind(nnkExprEqExpr)
       of LabelFmt: discard
+
       # handle regular named parameters
       let lname = arg[0].strVal
       let fp = fnParams[lname]
       varList[fp.idx] = (fp.name, arg[1])
       idx.inc
+
     else:
       # handle basic types like strlit or intlit
       varList[idx] = ("", arg)

--- a/src/cdecl/applies.nim
+++ b/src/cdecl/applies.nim
@@ -238,7 +238,7 @@ proc unpackLabelsImpl(
       ## handle prefixes
       # echo "LBL: ", arg.treeRepr
       if arg[0].kind == nnkPrefix:
-        let id = ident(arg[0].repr & arg[1].repr)
+        let id = ident(arg[0][0].strVal & arg[0][1].strVal)
         copyLineInfo(id, arg[0])
         arg[0] = id
       

--- a/tests/testApplies.nim
+++ b/tests/testApplies.nim
@@ -61,6 +61,14 @@ suite "unpack labels":
     template fooBar(blk: varargs[untyped]) =
       unpackLabelsAsArgs(foo, blk)
 
+    proc fooPrefix(`@name`: string = "buzz", a, b: int) =
+      # echo name, ":", " a: ", $a, " b: ", $b
+      wasRun = true
+      totalValue = a + b
+    
+    template FooBarPrefix(blk: varargs[untyped]) =
+      unpackLabelsAsArgs(fooPrefix, blk)
+
     proc fizz(name: proc (): string, a, b: int) =
       # echo name(), ":", " a: ", $a, " b: ", $b
       check name() == "fizzy"
@@ -111,6 +119,14 @@ suite "unpack labels":
     
     Foo:
       name: "buzz"
+      a: 11
+      b: 22
+    
+  test "test basic capitalized":
+    ## basic fooBar call
+    ## 
+    FooBarPrefix:
+      @name: "buzz"
       a: 11
       b: 22
     

--- a/tests/testApplies.nim
+++ b/tests/testApplies.nim
@@ -382,6 +382,25 @@ suite "unpack block args":
       withA = 11
       withB = 22
     
+  test "test transform basic":
+    ## basic fooBar call
+    ## 
+    let removeWiths {.compileTime.} =
+      proc (code: (string, NimNode)): Option[(string, NimNode)] =
+        if code[0].startsWith("with"):
+          result = some (code[0][4..^1].toLower(), code[1])
+        elif code[0].startsWith("@"):
+          echo "found magic"
+        else:
+          result = some code
+    template FooBar(blk: varargs[untyped]) =
+      removeWiths.unpackBlockArgsWithFn(foo, blk)
+    
+    FooBar:
+      @opt = true
+      withA = 11
+      withB = 22
+  
   test "test with pos arg":
     fooBar("buzz"):
       a = 11

--- a/tests/testApplies.nim
+++ b/tests/testApplies.nim
@@ -328,6 +328,14 @@ suite "unpack block args":
     template fooBar(blk: varargs[untyped]) =
       unpackBlockArgs(foo, blk)
 
+    proc fooPrefix(`@name`: string = "buzz", a, b: int) =
+      # echo name, ":", " a: ", $a, " b: ", $b
+      wasRun = true
+      totalValue = a + b
+    
+    template FooBarPrefix(blk: varargs[untyped]) =
+      unpackBlockArgs(fooPrefix, blk)
+
     proc fizz(name: proc (): string, a, b: int) =
       # echo name(), ":", " a: ", $a, " b: ", $b
       check name() == "fizzy"
@@ -381,6 +389,14 @@ suite "unpack block args":
       a = 11
       b = 22
     
+  test "test basic capitalized":
+    ## basic fooBar call
+    ## 
+    FooBarPrefix:
+      @name = "buzz"
+      a = 11
+      b = 22
+    
   test "test transform basic":
     ## basic fooBar call
     ## 
@@ -416,7 +432,7 @@ suite "unpack block args":
       @opt = true
       withA = 11
       withB = 22
-  
+
   test "test with pos arg":
     fooBar("buzz"):
       a = 11

--- a/tests/testApplies.nim
+++ b/tests/testApplies.nim
@@ -1,6 +1,7 @@
 import unittest
 import strutils
 import cdecl/applies
+import options
 
 {.push hint[XDeclaredButNotUsed](off).}
 
@@ -117,15 +118,35 @@ suite "unpack labels":
     ## basic fooBar call
     ## 
     let removeWiths {.compileTime.} =
-      proc (code: (string, NimNode)): (string, NimNode) = 
+      proc (code: (string, NimNode)): Option[(string, NimNode)] = 
         if code[0].startsWith("with"):
-          result = (code[0][4..^1].toLower(), code[1])
+          result = some (code[0][4..^1].toLower(), code[1])
         else:
-          result = code
+          result = some code
     template Foo(blk: varargs[untyped]) =
       removeWiths.unpackLabelsAsArgsWithFn(foo, blk)
     
     Foo:
+      name: "buzz"
+      withA: 11
+      withB: 22
+    
+  test "test transform basic":
+    ## basic fooBar call
+    ## 
+    let removeWiths {.compileTime.} =
+      proc (code: (string, NimNode)): Option[(string, NimNode)] = 
+        if code[0].startsWith("with"):
+          result = some (code[0][4..^1].toLower(), code[1])
+        elif code[0].startsWith("@"):
+          echo "option found"
+        else:
+          result = some code
+    template Foo(blk: varargs[untyped]) =
+      removeWiths.unpackLabelsAsArgsWithFn(foo, blk)
+    
+    Foo:
+      @opt: "test"
       name: "buzz"
       withA: 11
       withB: 22
@@ -348,11 +369,11 @@ suite "unpack block args":
     ## basic fooBar call
     ## 
     let removeWiths {.compileTime.} =
-      proc (code: (string, NimNode)): (string, NimNode) = 
+      proc (code: (string, NimNode)): Option[(string, NimNode)] = 
         if code[0].startsWith("with"):
-          result = (code[0][4..^1].toLower(), code[1])
+          result = some (code[0][4..^1].toLower(), code[1])
         else:
-          result = code
+          result = some code
     template Foo(blk: varargs[untyped]) =
       removeWiths.unpackBlockArgsWithFn(foo, blk)
     

--- a/tests/testApplies.nim
+++ b/tests/testApplies.nim
@@ -130,6 +130,13 @@ suite "unpack labels":
       a: 11
       b: 22
     
+  test "test basic capitalized":
+    ## basic fooBar call
+    ## 
+    FooBarPrefix(@name = "buzz"):
+      a: 11
+      b: 22
+    
   test "test transform basic":
     ## basic fooBar call
     ## 
@@ -394,6 +401,13 @@ suite "unpack block args":
     ## 
     FooBarPrefix:
       @name = "buzz"
+      a = 11
+      b = 22
+  
+  test "test basic capitalized":
+    ## basic fooBar call
+    ## 
+    FooBarPrefix(@name = "buzz"):
       a = 11
       b = 22
     


### PR DESCRIPTION
Adds support for prefix symbol support like: 

```nim
FooBar:
  @opt = true
  withA = 11
  withB = 22
```

This can be used with procs like: 


```nim
  proc fooPrefix(`@name`: string = "buzz", a, b: int) =
    # echo name, ":", " a: ", $a, " b: ", $b
    wasRun = true
    totalValue = a + b
```

or with filters: 

```nim
  test "test transform basic":
    ## basic fooBar call
    ## 
    let removeWiths {.compileTime.} =
      proc (code: (string, NimNode)): Option[(string, NimNode)] =
        if code[0].startsWith("with"):
          result = some (code[0][4..^1].toLower(), code[1])
        elif code[0].startsWith("@"):
          echo "found magic"
        else:
          result = some code
    template FooBar(blk: varargs[untyped]) =
      removeWiths.unpackBlockArgsWithFn(foo, blk)
    
    FooBar:
      @opt = true
      withA = 11
      withB = 22

```
